### PR TITLE
adding radosgw-admin period get

### DIFF
--- a/ses
+++ b/ses
@@ -65,6 +65,7 @@ if [ -x /usr/bin/ceph ]; then
     plugin_command "ceph --connect-timeout=$CT report" > $LOG/ceph/ceph-report 2>&1
     plugin_command "timeout $CT rados df" > $LOG/ceph/rados-df 2>&1
     plugin_command "timeout $CT rbd ls" > $LOG/ceph/rbd-ls 2>&1
+    plugin_command "radosgw-admin period get" > $LOG/ceph/radosgw-admin-period-get 2>&1
 
     ceph --connect-timeout=$CT pg dump_stuck inactive 2>/dev/null |
     sed -nEe 's/^([0-9]+\.[0-9a-f]+).*/\1/p' |


### PR DESCRIPTION
Whenever multizone or multisite configurations are present, this command is needed to understand the layout of the zones and their status.