### PR TITLE
Include `lrbd -o` output (bsc#1142789)

### DIFF
--- a/ses
+++ b/ses
@@ -255,6 +255,16 @@ if [ -e /var/log/ganesha/ganesha.log ]; then
 fi
 
 #############################################################
+section_header "iSCSI Gateway config"
+
+if [ -x /usr/sbin/lrbd ]; then
+    mkdir -p $LOG/ceph/conf/iscsi
+    plugin_command "lrbd -o" |
+        sed "s/\(\"password[^\"]*\":\) .*$/\1 \"$CENSORED\"/g" > $LOG/ceph/conf/iscsi/lrbd-o 2>&1
+    plugin_message "lrbd -o results copied to ceph/conf/iscsi/lrbd-o"
+fi
+
+#############################################################
 section_header "Ceph related services"
 
 plugin_command "systemctl status -l 'ceph*'"


### PR DESCRIPTION
Fixes: https://github.com/SUSE/supportutils-plugin-ses/issues/13
Signed-off-by: Tim Serong <tserong@suse.com>