### PR TITLE
run radosgw-admin commands only in presence of rgw pools

### DIFF
--- a/ses
+++ b/ses
@@ -73,7 +73,6 @@ if [ -x /usr/bin/ceph ]; then
     # remain, because their output is easier to read in a hurry ;)
     plugin_command "ceph ${ID} --connect-timeout=$CT report" > $LOG/ceph/ceph-report 2>&1
     plugin_command "timeout $CT rados ${ID} df" > $LOG/ceph/rados-df 2>&1
-    plugin_command "radosgw-admin ${ID} period get" > $LOG/ceph/radosgw-admin-period-get 2>&1
     plugin_command "ceph ${ID} --connect-timeout=$CT telemetry status" > $LOG/ceph/ceph-telemetry-status 2>&1
 
     timeout $CT ceph ${ID} osd pool ls detail 2>/dev/null |
@@ -87,6 +86,11 @@ if [ -x /usr/bin/ceph ]; then
                 > $LOG/ceph/images/${pool}/rbd-info-${image} 2>&1
         done
     done
+
+    timeout $CT ceph ${ID} osd pool ls detail 2>/dev/null |
+        grep -q "application rgw" &&
+        plugin_command "radosgw-admin ${ID} period get" > $LOG/ceph/radosgw-admin-period-get 2>&1
+
 
     ceph ${ID} --connect-timeout=$CT pg dump_stuck inactive 2>/dev/null |
     sed -nEe 's/^([0-9]+\.[0-9a-f]+).*/\1/p' |


### PR DESCRIPTION
This avoids the pools being created unintentionally if there was never a rgw
pool to begin with. Also using ceph osd lspools instead of checking ceph status
as rgw daemon need not be running, so pool application string should be
relatively a sureshot way to determine if there was a rgw configured

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1154133
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>