### PR TITLE
add `ceph balancer status` command

### DIFF
--- a/ses
+++ b/ses
@@ -75,6 +75,7 @@ if [ -x /usr/bin/ceph ]; then
     plugin_command "ceph ${ID} --connect-timeout=$CT report" > $LOG/ceph/ceph-report 2>&1
     plugin_command "timeout $CT rados ${ID} df" > $LOG/ceph/rados-df 2>&1
     plugin_command "ceph ${ID} --connect-timeout=$CT telemetry status" > $LOG/ceph/ceph-telemetry-status 2>&1
+    plugin_command "ceph ${ID} --connect-timeout=$CT balancer status" > $LOG/ceph/ceph-balancer-status 2>&1
 
     timeout $CT ceph ${ID} osd pool ls detail 2>/dev/null |
     sed -nEe "s/^.*'([^']+)'.* application rbd/\\1/p" |


### PR DESCRIPTION
SES6: supportconfig needs to provide output to "ceph balancer status"