### PR TITLE
Fixes for bsc#1177203 and bsc#1180796

### DIFF
--- a/ses-resources/helpers.sh
+++ b/ses-resources/helpers.sh
@@ -75,7 +75,8 @@ collect_info_from_ceph_cli() {
 
     plugin_command "$ceph_shell $CEPH versions" > "$LOGCEPH"/ceph-versions 2>&1
     plugin_command "$ceph_shell $CEPH health detail" > "$LOGCEPH"/ceph-health-detail 2>&1
-    plugin_command "$ceph_shell $CEPH config dump" > "$LOGCEPH"/ceph-config-dump 2>&1
+    plugin_command "$ceph_shell $CEPH config dump" 2>&1 |
+        sed "s/\(ACCESS_KEY\|SECRET_KEY\|PASSWORD\)\(\s*\).*/\1\2$CENSORED/gi" > "$LOGCEPH"/ceph-config-dump
     plugin_command "$ceph_shell $CEPH mon dump" > "$LOGCEPH"/ceph-mon-dump 2>&1
     plugin_command "$ceph_shell $CEPH mgr dump" > "$LOGCEPH"/ceph-mgr-dump 2>&1
     plugin_command "$ceph_shell $CEPH device ls" > "$LOGCEPH"/ceph-device-ls 2>&1

--- a/ses-resources/helpers.sh
+++ b/ses-resources/helpers.sh
@@ -78,6 +78,7 @@ collect_info_from_ceph_cli() {
     plugin_command "$ceph_shell $CEPH config dump" > "$LOGCEPH"/ceph-config-dump 2>&1
     plugin_command "$ceph_shell $CEPH mon dump" > "$LOGCEPH"/ceph-mon-dump 2>&1
     plugin_command "$ceph_shell $CEPH mgr dump" > "$LOGCEPH"/ceph-mgr-dump 2>&1
+    plugin_command "$ceph_shell $CEPH device ls" > "$LOGCEPH"/ceph-device-ls 2>&1
     plugin_command "$ceph_shell $CEPH osd tree" > "$LOGCEPH"/ceph-osd-tree 2>&1
     plugin_command "$ceph_shell $CEPH osd df tree" > "$LOGCEPH"/ceph-osd-df-tree 2>&1
     plugin_command "$ceph_shell $CEPH osd dump" > "$LOGCEPH"/ceph-osd-dump 2>&1


### PR DESCRIPTION
This adds `ceph device ls` output collection and censors authentication info in `ceph config dump` output.